### PR TITLE
Fix RAM values being different

### DIFF
--- a/scripts/game/ram_manager.gd
+++ b/scripts/game/ram_manager.gd
@@ -15,19 +15,27 @@ func _ready() -> void:
 	Global.use_ram.connect(_on_use_ram)
 	Global.use_enemy_ram.connect(_on_use_enemy_ram)
 
-	player_max_ram += 1
 	player_ram = player_max_ram
 	Global.player_ram_changed.emit(player_ram)
 	Global.update_max_ram.emit(player_max_ram)
 
-	opponent_max_ram += 1
 	opponent_ram = opponent_max_ram
 	Global.enemy_ram_changed.emit(opponent_ram)
 	Global.update_enemy_max_ram.emit(opponent_max_ram)
 
 
+func reset_ram(is_player_first: bool) -> void:
+	player_max_ram = 0
+	opponent_max_ram = 0
+
+	if !is_player_first:
+		_refresh_opponent_ram()
+
+	_refresh_player_ram()
+
+
 func _refresh_player_ram() -> void:
-	if player_max_ram != 10:
+	if player_max_ram < 10:
 		player_max_ram += 1
 		Global.update_max_ram.emit(player_max_ram)
 	player_ram = player_max_ram
@@ -35,7 +43,7 @@ func _refresh_player_ram() -> void:
 
 
 func _refresh_opponent_ram() -> void:
-	if opponent_max_ram != 10:
+	if opponent_max_ram < 10:
 		opponent_max_ram += 1
 		Global.update_enemy_max_ram.emit(opponent_max_ram)
 	opponent_ram = opponent_max_ram

--- a/scripts/ui/loading_screen.gd
+++ b/scripts/ui/loading_screen.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 	Global.network_manager.start_initial_packet_sequence()
 
 
-func __on_match_found(_packet: MatchFoundPacket) -> void:
+func __on_match_found(packet: MatchFoundPacket) -> void:
 	loading_text = "Match found"
 	var game = game_node.instantiate()
 	get_parent().add_child(game)
@@ -31,6 +31,7 @@ func __on_match_found(_packet: MatchFoundPacket) -> void:
 	Global.enemy_field = game.get_node("EnemyField")
 
 	Global.ram_manager = game.get_tree().get_first_node_in_group("ram_manager")
+	Global.ram_manager.reset_ram(packet.is_first_player)
 
 	queue_free()
 


### PR DESCRIPTION
This fixes RAM values being different on game start.

There shouldn't be any other de-sync at any other moments in the game, because we should be getting a packet for every action taken by any player in the field. Hence, it should be sufficient to fix RAM desync on game start.

Related card: https://github.com/orgs/NeuroTCG/projects/2?pane=issue&itemId=81370086