### PR TITLE
Add automatic updates

### DIFF
--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -10,7 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://dt020trjt7st3" path="res://scenes/game/enemy_field.tscn" id="8_pgxhr"]
 [ext_resource type="PackedScene" uid="uid://cu02rxao1axbe" path="res://scenes/game/card_viewer.tscn" id="10_4vhfg"]
 [ext_resource type="PackedScene" uid="uid://qbv47xh325e6" path="res://scenes/game/turn_indicator.tscn" id="11_dhnsn"]
-[ext_resource type="PackedScene" uid="uid://c74u03d47ybfw" path="res://scenes/ui/ram.tscn" id="11_jogws"]
+[ext_resource type="PackedScene" path="res://scenes/ui/ram.tscn" id="11_jogws"]
 [ext_resource type="Script" path="res://scripts/game/ram_manager.gd" id="12_ft7rt"]
 [ext_resource type="Script" path="res://scripts/game/passive_manager.gd" id="13_wjgx5"]
 

--- a/scenes/main/main.tscn
+++ b/scenes/main/main.tscn
@@ -1,6 +1,52 @@
-[gd_scene load_steps=2 format=3 uid="uid://clmgo8ks4p6nq"]
+[gd_scene load_steps=3 format=3 uid="uid://clmgo8ks4p6nq"]
 
 [ext_resource type="Script" path="res://scripts/main/main.gd" id="1_gki4g"]
+[ext_resource type="Script" path="res://scripts/main/updater.gd" id="2_agjuv"]
 
-[node name="Main" type="Node"]
+[node name="Main" type="Node2D"]
 script = ExtResource("1_gki4g")
+
+[node name="GameUpdater" type="CanvasLayer" parent="."]
+script = ExtResource("2_agjuv")
+
+[node name="Control" type="Control" parent="GameUpdater"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="GameUpdater/Control"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="Padding2" type="Control" parent="GameUpdater/Control/HBoxContainer"]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="GameUpdater/Control/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="UpdateStatusLabel" type="Label" parent="GameUpdater/Control/HBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+
+[node name="DownladProgressBar" type="ProgressBar" parent="GameUpdater/Control/HBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Padding" type="Control" parent="GameUpdater/Control/HBoxContainer"]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+
+[node name="HTTPRequest" type="HTTPRequest" parent="GameUpdater"]

--- a/scripts/main/main.gd
+++ b/scripts/main/main.gd
@@ -1,13 +1,19 @@
 extends Node
 
-var version := "early development build"
-
 var main_menu_template := preload("res://scenes/ui/main_menu.tscn")
 var loading_screen_template := preload("res://scenes/ui/loading_screen.tscn")
 @export var music_file: AudioStream
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
+func start_game() -> void:
+	get_node("GameUpdater").queue_free()
 	add_child(main_menu_template.instantiate())
 	AudioSystem.play_music(music_file)
+
+
+func _ready() -> void:
+	get_node("GameUpdater").update_done.connect(start_game)
+
+
+func _process(_delta: float) -> void:
+	pass

--- a/scripts/main/updater.gd
+++ b/scripts/main/updater.gd
@@ -1,0 +1,161 @@
+extends Node
+
+@onready var status_label: Label = %UpdateStatusLabel
+@onready var progress_bar: ProgressBar = %DownladProgressBar
+@onready var http_request: HTTPRequest = $HTTPRequest
+
+const VERSION_FILE_NAME := "user://version.txt"
+const LATEST_RELEASE_URL := "https://api.github.com/repos/NeuroTCG/Neuro-TCG-Client/releases/latest"
+
+var executable_extension := OS.get_executable_path().get_extension()
+var normal_executable_name := (
+	OS.get_executable_path().get_basename().trim_suffix(".tmp") + "." + executable_extension
+)
+var tmp_executable_name := OS.get_executable_path().get_basename() + ".tmp." + executable_extension
+
+var new_version := ""
+var current_version := "v0.0.0"
+
+signal update_done
+
+
+func _ready() -> void:
+	await get_parent().ready
+
+	if FileAccess.file_exists(VERSION_FILE_NAME):
+		var version_file = FileAccess.open(VERSION_FILE_NAME, FileAccess.READ)
+		current_version = version_file.get_as_text().strip_edges()
+		version_file.close()
+
+	if OS.has_feature("web") or OS.has_feature("editor"):
+		print("running in editor or on web. Not performing updates")
+		update_done.emit()
+		return
+
+	if executable_extension == "":
+		print("No executable extension detected.")
+		status_label.text = "We couldn't detect the game executable. Make sure it has the correct extension for your platform."
+		return
+
+	if OS.get_cmdline_args().count("--no-copy-back"):
+		print("--no-copy-back specified. Not performing copy")
+	elif OS.get_cmdline_args().count("--no-update"):
+		# this program is running from the temporary binary
+		await get_tree().create_timer(1).timeout # wait for the parent process to exit and close the file
+
+		print("--no-update argument specified. --no-copy-back not specified")
+		print("copying '%s' to '%s'" % [OS.get_executable_path(), normal_executable_name])
+		DirAccess.copy_absolute(OS.get_executable_path(), normal_executable_name)
+
+		update_done.emit()
+
+	else:
+		# this program is running from the normal binary
+		if FileAccess.file_exists(tmp_executable_name):
+			print("Found old update file. Removing")
+			DirAccess.remove_absolute(tmp_executable_name)
+
+	print("Checking for newer version")
+	status_label.text = "Checking for a newer version (Yours is %s)" % current_version
+	progress_bar.value = 0
+	http_request.request(LATEST_RELEASE_URL)
+
+	var request = await http_request.request_completed
+	var result = request[0] as HTTPRequest.Result
+	var response_code = request[1] as HTTPClient.ResponseCode
+	var _headers = request[2]
+	var body = request[3]
+
+	if result != HTTPRequest.RESULT_SUCCESS:
+		status_label.text = ("An error occured while checking for a new version: %s" % result)
+		return
+
+	if response_code != HTTPClient.RESPONSE_OK:
+		status_label.text = (
+			"An error occured while checking for a new version (%i): \n%s"
+			% [response_code, body.get_string_from_utf8()]
+		)
+		return
+
+	var latest_relesase_info = JSON.parse_string(body.get_string_from_utf8())
+
+	new_version = latest_relesase_info["tag_name"]
+	print("Current version is " + current_version)
+	print("Newest version is " + new_version)
+
+	if current_version == new_version:
+		print("No need to update. Starting game")
+		update_done.emit()
+		return
+
+	var new_executable_url := ""
+	for asset in latest_relesase_info["assets"]:
+		if asset["name"].ends_with(executable_extension):
+			new_executable_url = asset["browser_download_url"]
+			break
+		else:
+			print("Binary '%s' doesn't end with '%s'" % [asset["name"], executable_extension])
+
+	if new_executable_url == "":
+		status_label.text = (
+			"No release binary with extension '%s' was found. Either your platform isn't supported or there was an error"
+			% executable_extension
+		)
+		return
+
+	# new_executable_url = "http://localhost:3000/game.x86_64"
+
+	print("Downloading '%s'" % new_executable_url)
+	status_label.text = "Downloading %s" % new_version
+	http_request.request(new_executable_url)
+
+	request = await http_request.request_completed
+	result = request[0] as HTTPRequest.Result
+	response_code = request[1] as HTTPClient.ResponseCode
+	_headers = request[2]
+	body = request[3]
+
+	if result != HTTPRequest.RESULT_SUCCESS:
+		status_label.text = ("An error occured while downloading the new version: %s" % result)
+		return
+
+	if response_code != HTTPClient.RESPONSE_OK:
+		status_label.text = (
+			"An error occured while downloading the new version (%i): \n%s"
+			% [response_code, body.get_string_from_utf8()]
+		)
+		return
+
+	print("New version downloaded. Saving to %s" % tmp_executable_name)
+	var file = FileAccess.open(tmp_executable_name, FileAccess.WRITE)
+	file.store_buffer(body)
+	file.close()
+	FileAccess.set_unix_permissions(
+		tmp_executable_name,
+		(
+			FileAccess.UNIX_READ_OWNER
+			| FileAccess.UNIX_READ_GROUP
+			| FileAccess.UNIX_READ_OTHER
+			| FileAccess.UNIX_WRITE_OWNER
+			| FileAccess.UNIX_EXECUTE_OWNER
+			| FileAccess.UNIX_EXECUTE_GROUP
+			| FileAccess.UNIX_EXECUTE_OTHER
+		)
+	)  # chmod 755
+
+	var version_file = FileAccess.open(VERSION_FILE_NAME, FileAccess.WRITE)
+	version_file.store_string(new_version)
+	version_file.close()
+
+	print("Starting downloaded binary")
+
+	# the game doesn't start if we don't store the
+	# process and if we close this process to early
+	OS.create_process(tmp_executable_name, ["--no-update"])
+	get_tree().quit()
+
+
+func _process(_delta: float) -> void:
+	progress_bar.value = (
+		float(http_request.get_downloaded_bytes()) / float(http_request.get_body_size()) * 100
+	)


### PR DESCRIPTION
Checks for the latest release on github and downloads it to a temporary file. Starts the temporary file with "--no-update" which then copies itself back to the original. The temporary file gets removed on the next start. Also implements "--no-copy-back" for e.g. NixOS where binaries are read-only.

This won't run in the editor (obviously) so for testing you need to build it. (Also because the GH version doesn't have "--no-update" you need to build two different versions with a different print or something and serve one locally. Then overwrite new_executable_url)